### PR TITLE
fix plugin not running on Windows

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -46,7 +46,7 @@ export default function makePlugin(config: Config = {}): Plugin {
     }
   }
 
-  const sourceDirectory = path.resolve(cwd, (relayConfig['src'] as string) || './src');
+  const sourceDirectory = path.resolve(cwd, (relayConfig['src'] as string) || './src').split(path.sep).join(path.posix.sep);
   const artifactDirectory = relayConfig['artifactDirectory'];
   const codegenCommand = (relayConfig['codegenCommand'] as string) || 'relay-compiler';
   const module = config.module || (relayConfig['eagerEsModules'] ? 'esmodule' : 'commonjs');


### PR DESCRIPTION
Currently, the plugin is not applied to any files because of the wrong path handling.
On Windows. Vite passes strings that look like `C:/Users/foo/index.js` as `id` parameters of the `transform` hook.
However, the platform path implementation of NodeJS returns something like `C:\Users\foo\index.js`, which has different path separators.
This difference leads to the plugin never getting executed on Windows, since no module ID will start with `sourceDirectory`.
This PR fixes the issue by replacing the separators with the UNIX ones.
I didn't use `path.posix.resolve` because that doesn't put drive letters (`C:\`) at the front of the string.