### PR TITLE
fix: check file extensions via url parsing

### DIFF
--- a/.changeset/angry-dolls-refuse.md
+++ b/.changeset/angry-dolls-refuse.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-relay-lite": patch
+---
+
+Check file extensions via URL parsing

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -116,7 +116,8 @@ export default function makePlugin(options: PluginOptions = {}): Plugin {
         return;
       }
 
-      if (!/\.(c|m)?(j|t)sx?$/.test(id)) {
+      const url = new URL(id, 'file:');
+      if (!/\.(c|m)?(j|t)sx?$/.test(url.pathname)) {
         return;
       }
 


### PR DESCRIPTION
Update regular expression to allow module id that includes query suffix. (e.g. `/index.tsx?tsr-split`)

This is not common case, but would be help for me 😂