### PR TITLE
Default to ES modules to match Relay Compiler v19 behavior

### DIFF
--- a/.changeset/tiny-spiders-chew.md
+++ b/.changeset/tiny-spiders-chew.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-relay-lite": minor
+---
+
+Default to ES modules to match Relay Compiler v19 behavior

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ Or pass config object.
 
 ### ES Module Output
 
-Plugin respects the `eagerEsModules` option in the Relay config, so the default output format is `commonjs`.
+Plugin respects the `eagerEsModules` option in the Relay config, so the default output format is `esmodule`.
 
-However, using CommonJS in Vite projects may require additional config to transpile, and it's not recommended to use. Consider to set `eagerEsModules` to `true` in your Relay config, or set `module: 'esmodule'` in plugin options as you require.
+The plugin also supports CommonJS outputs with `eagerEsModules` set to `false` or `module: 'esmodule'` in plugin options.
+However, using CommonJS in Vite projects may require additional config to transpile, and it's not recommended to use.
 
 ### Relay Compiler Integration
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -105,7 +105,7 @@ export default function makePlugin(options: PluginOptions = {}): Plugin {
 
   const artifactDirectory = relayConfig['artifactDirectory'];
   const codegenCommand = (relayConfig['codegenCommand'] as string) || 'relay-compiler';
-  const module = options.module || ((relayConfig['eagerESModules'] || relayConfig['eagerEsModules']) ? 'esmodule' : 'commonjs');
+  const module = options.module || ((relayConfig['eagerESModules'] || relayConfig['eagerEsModules']) ?? true ? 'esmodule' : 'commonjs');
   const omitTagImport = options.omitTagImport ?? false;
   const shouldTransform = options.shouldTransform ?? defaultSourcePredicate;
 


### PR DESCRIPTION
This PR updates the plugin to follow the default value update in [the compiler](https://github.com/facebook/relay/commit/bd321a231397) and [the Babel plugin](https://github.com/facebook/relay/pull/4982).