### PR TITLE
Add package license metadata

### DIFF
--- a/.changeset/green-owls-smile.md
+++ b/.changeset/green-owls-smile.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-relay-lite": patch
+---
+
+Add package license metadata.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.12.0",
   "description": "Vite plugin for more convenient Relay experience",
   "homepage": "https://github.com/cometkim/vite-plugin-relay-lite",
+  "license": "MIT",
   "author": {
     "name": "Hyeseong Kim",
     "email": "hey@hyeseong.kim"


### PR DESCRIPTION
## Summary
- add MIT license metadata to the package manifest
- align package.json with the repository's existing MIT LICENSE file

## Verification
- npm view vite-plugin-relay-lite@latest license --json
- node manifest assertion for license metadata
- git diff --check
- npm pack --dry-run --ignore-scripts --json